### PR TITLE
Fixed crash for 00003.LANG / #2 + table macros

### DIFF
--- a/NGMCToolGUI/Previewer.cpp
+++ b/NGMCToolGUI/Previewer.cpp
@@ -38,7 +38,7 @@ namespace NGMC
 	{
 		if (m_File != nullptr)
 		{
-			ImGui::Text("GENERAL");
+			ImGui::TextUnformatted("GENERAL");
 
 			FileType type = m_File->GetType();
 
@@ -63,42 +63,20 @@ namespace NGMC
 
 			if (ImGui::BeginTable("tablePreviewerGeneral", 2, Preview::tableFlags))
 			{
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Name");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(m_File->GetName());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Type");
-				ImGui::TableSetColumnIndex(1); ImGui::Text("%s > %s", gameName.c_str(), typeName.c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Is file in memory");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(m_File->IsFileInMemory() ? "true" : "false");
+				ROW_CSTRING("Name", m_File->GetName());
+				ROW_PRINTF("Type", "%s > %s", gameName.c_str(), typeName.c_str());
+				ROW_CSTRING("Is file in memory", m_File->IsFileInMemory() ? "true" : "false");
 
 				if (!m_File->IsFileInMemory())
 				{
 					std::wstring filePath = m_File->GetFilePath();
-
-					ImGui::TableNextRow();
-					ImGui::TableSetColumnIndex(0); ImGui::Text("Path");
-					ImGui::TableSetColumnIndex(1); ImGui::Text(std::string(filePath.begin(), filePath.end()).c_str());
+					ROW_STRING("Path", std::string(filePath.begin(), filePath.end()));
 				}
 				
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Is file loaded");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(m_File->IsLoaded() ? "true" : "false");
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Size");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(m_File->GetSize()).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Index in Parent");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_File->GetIndexInParent()).c_str());
-				
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Child count");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_File->GetChildCount()).c_str());
+				ROW_CSTRING("Is file loaded", m_File->IsLoaded() ? "true" : "false");
+				ROW_SIZE("Size", m_File->GetSize());
+				ROW_VALUE("Index in Parent", m_File->GetIndexInParent());
+				ROW_VALUE("Child count", m_File->GetChildCount());
 
 				ImGui::EndTable();
 			}
@@ -120,14 +98,14 @@ namespace NGMC
 			else
 			{
 				if (type.IsUnknown())
-					ImGui::Text("Format unknown. Right-click the file and set a type manually.");
+					ImGui::TextUnformatted("Format unknown. Right-click the file and set a type manually.");
 				else
-					ImGui::Text("This format is not yet supported for previewing.");
+					ImGui::TextUnformatted("This format is not yet supported for previewing.");
 			}
 		}
 		else
 		{
-			ImGui::Text("Select an element in the content viewer to see a preview of its data here.");
+			ImGui::TextUnformatted("Select an element in the content viewer to see a preview of its data here.");
 		}
 	}
 

--- a/NGMCToolGUI/UI.cpp
+++ b/NGMCToolGUI/UI.cpp
@@ -399,7 +399,7 @@ namespace NGMC
 			{
 				ImGui::Separator();
 
-				ImGui::Text("GT1G:");
+				ImGui::TextUnformatted("GT1G:");
 				if (ImGui::MenuItem("Render Color Map as raw data (color index)", NULL, &g_ReadColorMapAsLuminance))
 				{
 					previewer.Prepare();
@@ -541,8 +541,8 @@ namespace NGMC
 				}
 
 				ImGui::Separator();
-				ImGui::Text((std::string("Type: ") + type.GetTypeName() + std::format(" (0x{:02X})", (char)type.GetId())).c_str());
-				ImGui::Text((std::string("Size: ") + GetPrettySize(p_File->GetSize())).c_str());
+				ImGui::TextUnformatted((std::string("Type: ") + type.GetTypeName() + std::format(" (0x{:02X})", (char)type.GetId())).c_str());
+				ImGui::TextUnformatted((std::string("Size: ") + GetPrettySize(p_File->GetSize())).c_str());
 				ImGui::Separator();
 			}
 			else if (selectionCount > 1)
@@ -561,14 +561,14 @@ namespace NGMC
 				}
 
 				ImGui::Separator();
-				ImGui::Text(std::format("{} items selected", fileManager.GetSelectionCount()).c_str());
+				ImGui::TextUnformatted(std::format("{} items selected", fileManager.GetSelectionCount()).c_str());
 
 				uintmax_t size = 0ULL;
 				for (unsigned int i = 0; i < selectionCount; i++)
 				{
 					size += fileManager.GetSelectedFile(i)->GetSize();
 				}
-				ImGui::Text((std::string("Size: ") + GetPrettySize(size)).c_str());
+				ImGui::TextUnformatted((std::string("Size: ") + GetPrettySize(size)).c_str());
 				ImGui::Separator();
 			}
 
@@ -858,7 +858,7 @@ namespace NGMC
 		//ImGui::Separator();
 		//ImGui::Dummy(ImVec2(0.0f, 2.0f));
 		//
-		//ImGui::Text(std::format("Popup count: {}", popups.size()).c_str());
+		//ImGui::TextUnformatted(std::format("Popup count: {}", popups.size()).c_str());
 
 		ImGui::End();
 	}

--- a/NGMCToolGUI/popups/PopupAbout.cpp
+++ b/NGMCToolGUI/popups/PopupAbout.cpp
@@ -27,9 +27,9 @@ namespace NGMC
 	{
 		ImGui::Dummy({ 0.0f, 0.0f });
 		ImGui::SetCursorPosX((ImGui::CalcTextSize(longDesc).x - ImGui::CalcTextSize(appTitle).x) / 2);
-		ImGui::Text(appTitle);
+		ImGui::TextUnformatted(appTitle);
 		ImGui::Dummy({ 0.0f, 0.0f });
-		ImGui::Text(longDesc);
+		ImGui::TextUnformatted(longDesc);
 		ImGui::Dummy({ 0.0f, 0.0f });
 
 		ImGui::Separator();
@@ -38,29 +38,9 @@ namespace NGMC
 
 		if (ImGui::BeginTable("tableAbout", 2))
 		{
-			ImGui::TableNextRow();
-
-			ImGui::TableSetColumnIndex(0);
-			ImGui::Text("Version");
-
-			ImGui::TableSetColumnIndex(1);
-			ImGui::Text(std::format("{:X}.{:X}.{:X}", (g_ApplicationVersion >> 16) & 0xFF, (g_ApplicationVersion >> 8) & 0xFF, g_ApplicationVersion & 0xFF).c_str());
-			
-			ImGui::TableNextRow();
-
-			ImGui::TableSetColumnIndex(0);
-			ImGui::Text("Author");
-
-			ImGui::TableSetColumnIndex(1);
-			ImGui::Text("Mystixor");
-			
-			ImGui::TableNextRow();
-
-			ImGui::TableSetColumnIndex(0);
-			ImGui::Text("Contributors");
-
-			ImGui::TableSetColumnIndex(1);
-			ImGui::Text("");
+			ROW_FORMAT("Version", "{:X}.{:X}.{:X}", (g_ApplicationVersion >> 16) & 0xFF, (g_ApplicationVersion >> 8) & 0xFF, g_ApplicationVersion & 0xFF);
+			ROW_CSTRING("Author", "Mystixor");
+			ROW_CSTRING("Contributors", "");
 
 			ImGui::EndTable();
 		}

--- a/NGMCToolGUI/popups/PopupBuildGT1G.cpp
+++ b/NGMCToolGUI/popups/PopupBuildGT1G.cpp
@@ -93,7 +93,7 @@ namespace NGMC
 		if (ImGui::BeginChild("childWindowPopupBuildGT1GTextureList", { 0.0f, -footer_height_to_reserve }, ImGuiChildFlags_Border, ImGuiWindowFlags_AlwaysVerticalScrollbar))
 		{
 			if (m_TextureCount == 0)
-				ImGui::Text("Increase count above to edit textures here.");
+				ImGui::TextUnformatted("Increase count above to edit textures here.");
 
 			for (unsigned int i = 0; i < m_TextureCount; i++)
 			{
@@ -123,7 +123,7 @@ namespace NGMC
 						}
 
 						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("File input:");
+						ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("File input:");
 
 						ImGui::TableNextRow();
 						ImGui::TableSetColumnIndex(0);
@@ -136,11 +136,11 @@ namespace NGMC
 								ImGui::TableSetColumnIndex(0);
 								if (m_TextureFilePathDisplays[i].length() == 0)
 								{
-									ImGui::Text("No file selected");
+									ImGui::TextUnformatted("No file selected");
 								}
 								else
 								{
-									ImGui::Text(m_TextureFilePathDisplays[i].c_str());
+									ImGui::TextUnformatted(m_TextureFilePathDisplays[i].c_str());
 								}
 
 								ImGui::EndTable();
@@ -148,7 +148,7 @@ namespace NGMC
 
 							if (ImGui::BeginItemTooltip())
 							{
-								ImGui::Text("Text field does not support UTF-16, but if you pick a file using the Browse button it will work correctly nonetheless");
+								ImGui::TextUnformatted("Text field does not support UTF-16, but if you pick a file using the Browse button it will work correctly nonetheless");
 								ImGui::EndTooltip();
 							}
 
@@ -208,11 +208,11 @@ namespace NGMC
 								ImGui::TableSetColumnIndex(0);
 								if (m_TextureFilePointers[i] == nullptr)
 								{
-									ImGui::Text("No file selected");
+									ImGui::TextUnformatted("No file selected");
 								}
 								else
 								{
-									ImGui::Text(m_TextureFilePointers[i]->GetName());
+									ImGui::TextUnformatted(m_TextureFilePointers[i]->GetName());
 								}
 								ImGui::EndTable();
 							}
@@ -230,7 +230,7 @@ namespace NGMC
 
 
 						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("Width:");
+						ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("Width:");
 
 						ImGui::TableNextRow();
 						ImGui::TableSetColumnIndex(0);
@@ -248,7 +248,7 @@ namespace NGMC
 
 
 						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("Height:");
+						ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("Height:");
 
 						ImGui::TableNextRow();
 						ImGui::TableSetColumnIndex(0);
@@ -266,7 +266,7 @@ namespace NGMC
 
 
 						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("MipMap Count:");
+						ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("MipMap Count:");
 
 						ImGui::TableNextRow();
 						ImGui::TableSetColumnIndex(0);
@@ -280,7 +280,7 @@ namespace NGMC
 
 
 						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("Format:");
+						ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("Format:");
 
 						ImGui::TableNextRow();
 						ImGui::TableSetColumnIndex(0);
@@ -316,7 +316,7 @@ namespace NGMC
 		ImGui::Dummy(ImVec2(0.0f, spacing));
 
 		ImGui::PushItemWidth(ImGui::GetWindowSize().x - 97.0f);
-		ImGui::Text("File name:");
+		ImGui::TextUnformatted("File name:");
 		if (ImGui::InputText("##inputFileName", (char*)m_OutputName.c_str(), 256))
 		{
 			m_OutputName = m_OutputName.c_str();

--- a/NGMCToolGUI/popups/PopupFilePicker.cpp
+++ b/NGMCToolGUI/popups/PopupFilePicker.cpp
@@ -162,7 +162,7 @@ namespace NGMC
 			else
 			{
 				ImGui::SetCursorPosY(ImGui::GetCursorPosY() + ImGui::GetStyle().FramePadding.y);
-				ImGui::Text(std::format("Select a file of type \"{}\"", m_AcceptType.GetTypeName()).c_str());
+				ImGui::TextUnformatted(std::format("Select a file of type \"{}\"", m_AcceptType.GetTypeName()).c_str());
 			}
 
 			ImGui::TableSetColumnIndex(2);

--- a/NGMCToolGUI/popups/PopupRenameFile.cpp
+++ b/NGMCToolGUI/popups/PopupRenameFile.cpp
@@ -32,7 +32,7 @@ namespace NGMC
 
 	void PopupRenameFile::OnRenderContent()
 	{
-		ImGui::Text("File name:");
+		ImGui::TextUnformatted("File name:");
 		
 		ImGui::PushItemWidth(ImGui::GetWindowSize().x - 2 * ImGui::GetStyle().WindowPadding.x);
 		if (ImGui::InputText("##newName", (char*)m_NewName.c_str(), 128))

--- a/NGMCToolGUI/popups/PopupSelectGame.cpp
+++ b/NGMCToolGUI/popups/PopupSelectGame.cpp
@@ -30,14 +30,14 @@ namespace NGMC
 
 	void PopupSelectGame::OnRenderContent()
 	{
-		ImGui::Text("Please select the Game which this file belongs to:");
+		ImGui::TextUnformatted("Please select the Game which this file belongs to:");
 
 		if (ImGui::BeginTable("tableFileInputForBorders", 1, ImGuiTableFlags_BordersOuter))
 		{
 			ImGui::TableNextRow();
 			ImGui::TableSetColumnIndex(0);
 
-			ImGui::Text((std::string("\"") + GetFile()->GetName() + "\"").c_str());
+			ImGui::TextUnformatted((std::string("\"") + GetFile()->GetName() + "\"").c_str());
 
 			ImGui::EndTable();
 		}

--- a/NGMCToolGUI/previews/PreviewDDS.cpp
+++ b/NGMCToolGUI/previews/PreviewDDS.cpp
@@ -37,16 +37,12 @@ namespace NGMC
 		ImGui::Separator();
 		ImGui::Dummy(ImVec2(0.0f, 5.0f));
 
-		ImGui::Text("DDS_HEADER");
+		ImGui::TextUnformatted("DDS_HEADER");
 
 		if (ImGui::BeginTable("tablePreviewerDDS_HEADER", 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwSize");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(m_DDS_HEADER.dwSize).c_str());
+			ROW_SIZE("dwSize", m_DDS_HEADER.dwSize);
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwFlags");
 			std::string flagsStr =
 				std::string((m_DDS_HEADER.dwFlags & DDSD_CAPS ? "DDSD_CAPS | " : "")) +
 				(m_DDS_HEADER.dwFlags & DDSD_HEIGHT ? "DDSD_HEIGHT | " : "") +
@@ -56,44 +52,20 @@ namespace NGMC
 				(m_DDS_HEADER.dwFlags & DDSD_MIPMAPCOUNT ? "DDSD_MIPMAPCOUNT | " : "") +
 				(m_DDS_HEADER.dwFlags & DDSD_LINEARSIZE ? "DDSD_LINEARSIZE | " : "") +
 				(m_DDS_HEADER.dwFlags & DDSD_DEPTH ? "DDSD_DEPTH | " : "");
-			ImGui::TableSetColumnIndex(1); ImGui::Text((std::format("0x{:08X}", m_DDS_HEADER.dwFlags) + (m_DDS_HEADER.dwFlags ? std::format(" ({})", flagsStr.substr(0, flagsStr.length() ? flagsStr.length() - 3 : 0)) : "")).c_str());
+			ROW_STRING("dwFlags", std::format("0x{:08X}", m_DDS_HEADER.dwFlags) + (m_DDS_HEADER.dwFlags ? std::format(" ({})", flagsStr.substr(0, flagsStr.length() ? flagsStr.length() - 3 : 0)) : ""));
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwHeight");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DDS_HEADER.dwHeight).c_str());
+			ROW_VALUE("dwHeight", m_DDS_HEADER.dwHeight);
+			ROW_VALUE("dwWidth", m_DDS_HEADER.dwWidth);
+			ROW_VALUE("dwPitchOrLinearSize", m_DDS_HEADER.dwPitchOrLinearSize);
+			ROW_VALUE("dwDepth", m_DDS_HEADER.dwDepth);
+			ROW_VALUE("dwMipMapCount", m_DDS_HEADER.dwMipMapCount);
+			ROW_STRING("dwReserved1", std::string("\"") + (char*)m_DDS_HEADER.dwReserved1 + "\"");
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwWidth");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DDS_HEADER.dwWidth).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwPitchOrLinearSize");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DDS_HEADER.dwPitchOrLinearSize).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwDepth");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DDS_HEADER.dwDepth).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwMipMapCount");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DDS_HEADER.dwMipMapCount).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwReserved1");
-			ImGui::TableSetColumnIndex(1); ImGui::Text((std::string("\"") + (char*)m_DDS_HEADER.dwReserved1 + "\"").c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("ddspf");
-			ImGui::TableSetColumnIndex(1);
-
+			ROW_BEGIN("ddspf");
 			if (ImGui::BeginTable("tablePreviewerDDS_HEADERddspf", 2, Preview::tableFlags))
 			{
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwSize");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(m_DDS_HEADER.ddspf.dwSize).c_str());
+				ROW_SIZE("dwSize", m_DDS_HEADER.ddspf.dwSize);
 
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwFlags");
 				std::string ddspfFlagsStr =
 					std::string((m_DDS_HEADER.ddspf.dwFlags & DDPF_ALPHAPIXELS ? "DDPF_ALPHAPIXELS | " : "")) +
 					(m_DDS_HEADER.ddspf.dwFlags & DDPF_ALPHA ? "DDPF_ALPHA | " : "") +
@@ -101,45 +73,24 @@ namespace NGMC
 					(m_DDS_HEADER.ddspf.dwFlags & DDPF_RGB ? "DDPF_RGB | " : "") +
 					(m_DDS_HEADER.ddspf.dwFlags & DDPF_YUV ? "DDPF_YUV | " : "") +
 					(m_DDS_HEADER.ddspf.dwFlags & DDPF_LUMINANCE ? "DDPF_LUMINANCE | " : "");
-				ImGui::TableSetColumnIndex(1); ImGui::Text((std::format("0x{:08X}", m_DDS_HEADER.ddspf.dwFlags) + (m_DDS_HEADER.ddspf.dwFlags ? std::format(" ({})", ddspfFlagsStr.substr(0, ddspfFlagsStr.length() ? ddspfFlagsStr.length() - 3 : 0)) : "")).c_str());
+				ROW_STRING("dwFlags", std::format("0x{:08X}", m_DDS_HEADER.ddspf.dwFlags) + (m_DDS_HEADER.ddspf.dwFlags ? std::format(" ({})", ddspfFlagsStr.substr(0, ddspfFlagsStr.length() ? ddspfFlagsStr.length() - 3 : 0)) : ""));
 
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwFourCC");
-				ImGui::TableSetColumnIndex(1); ImGui::Text((std::string("\"") + (char*)&m_DDS_HEADER.ddspf.dwFourCC + "\"").c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwRGBBitCount");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DDS_HEADER.ddspf.dwRGBBitCount).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwRBitMask");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_DDS_HEADER.ddspf.dwRBitMask).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwGBitMask");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_DDS_HEADER.ddspf.dwGBitMask).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwBBitMask");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_DDS_HEADER.ddspf.dwBBitMask).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dwABitMask");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_DDS_HEADER.ddspf.dwABitMask).c_str());
+				ROW_STRING("dwFourCC", std::string("\"") + (char*)&m_DDS_HEADER.ddspf.dwFourCC + "\"");
+				ROW_VALUE("dwRGBBitCount", m_DDS_HEADER.ddspf.dwRGBBitCount);
+				ROW_VALUE("dwRBitMask", m_DDS_HEADER.ddspf.dwRBitMask);
+				ROW_VALUE("dwGBitMask", m_DDS_HEADER.ddspf.dwGBitMask);
+				ROW_VALUE("dwBBitMask", m_DDS_HEADER.ddspf.dwBBitMask);
+				ROW_VALUE("dwABitMask", m_DDS_HEADER.ddspf.dwABitMask);
 
 				ImGui::EndTable();
 			}
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwCaps");
 			std::string capsStr =
 				std::string((m_DDS_HEADER.dwCaps & DDSCAPS_COMPLEX ? "DDSCAPS_COMPLEX | " : "")) +
 				(m_DDS_HEADER.dwCaps & DDSCAPS_MIPMAP ? "DDSCAPS_MIPMAP | " : "") +
 				(m_DDS_HEADER.dwCaps & DDSCAPS_TEXTURE ? "DDSCAPS_TEXTURE | " : "");
-			ImGui::TableSetColumnIndex(1); ImGui::Text((std::format("0x{:08X}", m_DDS_HEADER.dwCaps) + (m_DDS_HEADER.dwCaps ? std::format(" ({})", capsStr.substr(0, capsStr.length() ? capsStr.length() - 3 : 0)) : "")).c_str());
+			ROW_STRING("dwCaps", std::format("0x{:08X}", m_DDS_HEADER.dwCaps) + (m_DDS_HEADER.dwCaps ? std::format(" ({})", capsStr.substr(0, capsStr.length() ? capsStr.length() - 3 : 0)) : ""));
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwCaps2");
 			std::string caps2Str =
 				std::string((m_DDS_HEADER.dwCaps2 & DDSCAPS2_CUBEMAP ? "DDSCAPS2_CUBEMAP | " : "")) +
 				(m_DDS_HEADER.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEX ? "DDSCAPS2_CUBEMAP_POSITIVEX | " : "") +
@@ -149,19 +100,11 @@ namespace NGMC
 				(m_DDS_HEADER.dwCaps2 & DDSCAPS2_CUBEMAP_POSITIVEZ ? "DDSCAPS2_CUBEMAP_POSITIVEZ | " : "") +
 				(m_DDS_HEADER.dwCaps2 & DDSCAPS2_CUBEMAP_NEGATIVEZ ? "DDSCAPS2_CUBEMAP_NEGATIVEZ | " : "") +
 				(m_DDS_HEADER.dwCaps2 & DDSCAPS2_VOLUME ? "DDSCAPS2_VOLUME | " : "");
-			ImGui::TableSetColumnIndex(1); ImGui::Text((std::format("0x{:08X}", m_DDS_HEADER.dwCaps2) + (m_DDS_HEADER.dwCaps2 ? std::format(" ({})", caps2Str.substr(0, caps2Str.length() ? caps2Str.length() - 3 : 0)) : "")).c_str());
+			ROW_STRING("dwCaps2", std::format("0x{:08X}", m_DDS_HEADER.dwCaps2) + (m_DDS_HEADER.dwCaps2 ? std::format(" ({})", caps2Str.substr(0, caps2Str.length() ? caps2Str.length() - 3 : 0)) : ""));
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwCaps3");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_DDS_HEADER.dwCaps3).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwCaps4");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_DDS_HEADER.dwCaps4).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dwReserved2");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DDS_HEADER.dwReserved2).c_str());
+			ROW_VALUE("dwCaps3", m_DDS_HEADER.dwCaps3);
+			ROW_VALUE("dwCaps4", m_DDS_HEADER.dwCaps4);
+			ROW_VALUE("dwReserved2", m_DDS_HEADER.dwReserved2);
 
 			ImGui::EndTable();
 		}

--- a/NGMCToolGUI/previews/PreviewDatabin.cpp
+++ b/NGMCToolGUI/previews/PreviewDatabin.cpp
@@ -14,53 +14,18 @@ namespace NGMC
 	{
 		if (ImGui::BeginTable("tablePreviewerDatabin", 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_00");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.dat_00).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_04");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.dat_04).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_08");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.dat_08).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_0C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.dat_0C).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("headerSize");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(m_DatabinHeader.headerSize).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("fileDataOffset");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(m_DatabinHeader.fileDataOffset).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_18");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.dat_18).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_1C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.dat_1C).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("fileCount");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.fileCount).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("fileIndicesOffset");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(m_DatabinHeader.fileIndicesOffset).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("fileCount1");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.fileCount1).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_2C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinHeader.dat_2C).c_str());
+			ROW_VALUE("dat_00", m_DatabinHeader.dat_00);
+			ROW_VALUE("dat_04", m_DatabinHeader.dat_04);
+			ROW_VALUE("dat_08", m_DatabinHeader.dat_08);
+			ROW_VALUE("dat_0C", m_DatabinHeader.dat_0C);
+			ROW_SIZE("headerSize", m_DatabinHeader.headerSize);
+			ROW_SIZE("fileDataOffset", m_DatabinHeader.fileDataOffset);
+			ROW_VALUE("dat_18", m_DatabinHeader.dat_18);
+			ROW_VALUE("dat_1C", m_DatabinHeader.dat_1C);
+			ROW_VALUE("fileCount", m_DatabinHeader.fileCount);
+			ROW_VALUE("fileIndicesOffset", m_DatabinHeader.fileIndicesOffset);
+			ROW_VALUE("fileCount1", m_DatabinHeader.fileCount1);
+			ROW_VALUE("dat_2C", m_DatabinHeader.dat_2C);
 
 			ImGui::EndTable();
 		}

--- a/NGMCToolGUI/previews/PreviewDatabinItem.cpp
+++ b/NGMCToolGUI/previews/PreviewDatabinItem.cpp
@@ -54,86 +54,37 @@ namespace NGMC
 			}
 			}
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("offset");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", offset).c_str());
+			ROW_FORMAT("offset", "0x{:08X}", offset);
+			ROW_VALUE("dat_04", dat_04);
+			ROW_SIZE("size", size);
+			ROW_SIZE("sizeCompressed", sizeCompressed);
+			ROW_VALUE("dat_10", dat_10);
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_04");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", dat_04).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("size");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(size).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("sizeCompressed");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(sizeCompressed).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_10");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", dat_10).c_str());
 
 			switch (game)
 			{
 			case SIGMA_1:
 			{
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("indexLinkedFile0");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinItemHeaderS1.indexLinkedFile0).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("indexLinkedFile1");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinItemHeaderS1.indexLinkedFile1).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("typeLinkedFile0");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:02X} ({})", m_DatabinItemHeaderS1.typeLinkedFile0, GetFileExtension((Databin::S1::FileTypeId)m_DatabinItemHeaderS1.typeLinkedFile0)).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("typeLinkedFile1");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:02X} ({})", m_DatabinItemHeaderS1.typeLinkedFile1, GetFileExtension((Databin::S1::FileTypeId)m_DatabinItemHeaderS1.typeLinkedFile1)).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("type");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:02X} ({})", m_DatabinItemHeaderS1.type, GetFileExtension((Databin::S1::FileTypeId)m_DatabinItemHeaderS1.type)).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dat_1B");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinItemHeaderS1.dat_1B).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("dat_1C");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinItemHeaderS1.dat_1C).c_str());
-
+				ROW_VALUE("indexLinkedFile0", m_DatabinItemHeaderS1.indexLinkedFile0);
+				ROW_VALUE("indexLinkedFile1", m_DatabinItemHeaderS1.indexLinkedFile1);
+				ROW_FORMAT("typeLinkedFile0", "0x{:02X} ({})", m_DatabinItemHeaderS1.typeLinkedFile0, GetFileExtension((Databin::S1::FileTypeId)m_DatabinItemHeaderS1.typeLinkedFile0));
+				ROW_FORMAT("typeLinkedFile1", "0x{:02X} ({})", m_DatabinItemHeaderS1.typeLinkedFile1, GetFileExtension((Databin::S1::FileTypeId)m_DatabinItemHeaderS1.typeLinkedFile1));
+				ROW_FORMAT("type", "0x{:02X} ({})", m_DatabinItemHeaderS1.type, GetFileExtension((Databin::S1::FileTypeId)m_DatabinItemHeaderS1.type));
+				ROW_VALUE("dat_1B", m_DatabinItemHeaderS1.dat_1B);
+				ROW_VALUE("dat_1C", m_DatabinItemHeaderS1.dat_1C);
 				break;
 			}
 			case SIGMA_2:
 			{
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("indexLinkedFile");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinItemHeaderS2.indexLinkedFile).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("typeLinkedFile");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:02X} ({})", m_DatabinItemHeaderS2.typeLinkedFile, GetFileExtension((Databin::S2::FileTypeId)m_DatabinItemHeaderS2.typeLinkedFile)).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("type");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:02X} ({})", m_DatabinItemHeaderS2.type, GetFileExtension((Databin::S2::FileTypeId)m_DatabinItemHeaderS2.type)).c_str());
-
+				ROW_VALUE("indexLinkedFile", m_DatabinItemHeaderS2.indexLinkedFile);
+				ROW_FORMAT("typeLinkedFile", "0x{:02X} ({})", m_DatabinItemHeaderS2.typeLinkedFile, GetFileExtension((Databin::S2::FileTypeId)m_DatabinItemHeaderS2.typeLinkedFile));
+				ROW_FORMAT("type", "0x{:02X} ({})", m_DatabinItemHeaderS2.type, GetFileExtension((Databin::S2::FileTypeId)m_DatabinItemHeaderS2.type));
 				break;
 			}
 			case RE_3:
 			{
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("type");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X} ({})", m_DatabinItemHeaderRE.type, GetFileExtension((Databin::RE::FileTypeId)m_DatabinItemHeaderRE.type)).c_str());
-
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("indexLinkedFile");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_DatabinItemHeaderRE.indexLinkedFile).c_str());
-
+				ROW_FORMAT("type", "0x{:08X} ({})", m_DatabinItemHeaderRE.type, GetFileExtension((Databin::RE::FileTypeId)m_DatabinItemHeaderRE.type));
+				ROW_VALUE("indexLinkedFile", m_DatabinItemHeaderRE.indexLinkedFile);
 				break;
 			}
 			}

--- a/NGMCToolGUI/previews/PreviewGT1G.cpp
+++ b/NGMCToolGUI/previews/PreviewGT1G.cpp
@@ -18,30 +18,12 @@ namespace NGMC
 
 		if (ImGui::BeginTable("tablePreviewerGT1G", 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Version");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}.{}.{}.{}", (char)m_GT1GHeader.version.major, (char)m_GT1GHeader.version.submajor, (char)m_GT1GHeader.version.minor, (char)m_GT1GHeader.version.patch).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("fileSize");
-			std::string prettyFileSize = GetPrettySize(m_GT1GHeader.fileSize);
-			ImGui::TableSetColumnIndex(1); ImGui::Text(prettyFileSize.c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("textureOffsetTableAddress");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_GT1GHeader.textureOffsetTableAddress).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("textureCount");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_GT1GHeader.textureCount).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_14");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_GT1GHeader.dat_14).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_18");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", m_GT1GHeader.dat_18).c_str());
+			ROW_FORMAT("Version", "{}.{}.{}.{}", (char)m_GT1GHeader.version.major, (char)m_GT1GHeader.version.submajor, (char)m_GT1GHeader.version.minor, (char)m_GT1GHeader.version.patch);
+			ROW_SIZE("fileSize", m_GT1GHeader.fileSize);
+			ROW_FORMAT("textureOffsetTableAddress", "0x{:08X}", m_GT1GHeader.textureOffsetTableAddress);
+			ROW_VALUE("textureCount", m_GT1GHeader.textureCount);
+			ROW_VALUE("dat_14", m_GT1GHeader.dat_14);
+			ROW_VALUE("dat_18", m_GT1GHeader.dat_18);
 
 			ImGui::EndTable();
 		}
@@ -52,7 +34,7 @@ namespace NGMC
 
 		if (m_GT1GHeader.textureCount)
 		{
-			ImGui::Text("Preview texture");
+			ImGui::TextUnformatted("Preview texture");
 
 			ImGui::PushItemWidth(100.0f);
 			if (ImGui::InputInt("Texture index", (int*)&m_PreviewGT1GTexIdx))
@@ -99,68 +81,56 @@ namespace NGMC
 				ImGui::Dummy(ImVec2(0.0f, 5.0f));
 				ImGui::Separator();
 				ImGui::Dummy(ImVec2(0.0f, 5.0f));
-				ImGui::Text(std::format("Texture #{}", i).c_str());
+				ImGui::TextUnformatted(std::format("Texture #{}", i).c_str());
 
 				if (ImGui::BeginTable(std::format("tablePreviewerGT1GTexture{}", i).c_str(), 2, Preview::tableFlags))
 				{
-					ImGui::TableNextRow();
-					ImGui::TableSetColumnIndex(0); ImGui::Text("Pixel format");
-					ImGui::TableSetColumnIndex(1);
-
+					ROW_BEGIN("Pixel format");
 					switch (m_GT1GTextures[i].Format)
 					{
 					case PixelFormat::RGBA8_BGRA_u8:
-						ImGui::Text("BGRA"); break;
+						ImGui::TextUnformatted("BGRA");
+						break;
 					case PixelFormat::RGBA8_RGBA_u8:
 					case PixelFormat::CompressedRgbaS3tcDxt5Ext_08:
 					case PixelFormat::CompressedRgbaS3tcDxt5Ext_5B:
-						ImGui::Text("RGBA"); break;
+						ImGui::TextUnformatted("RGBA");
+						break;
 					case PixelFormat::CompressedRgbS3tcDxt1Ext_06:
 					case PixelFormat::CompressedRgbS3tcDxt1Ext_59:
-						ImGui::Text("RGB"); break;
+						ImGui::TextUnformatted("RGB");
+						break;
 					case PixelFormat::ColorMap_u8:
-						ImGui::Text("Color Map index"); break;
+						ImGui::TextUnformatted("Color Map index");
+						break;
 					default:
-						ImGui::Text("unknown");
+						ImGui::TextUnformatted("unknown");
 					}
 
-					ImGui::TableNextRow();
-					ImGui::TableSetColumnIndex(0); ImGui::Text("Compression");
-					ImGui::TableSetColumnIndex(1);
-
+					ROW_BEGIN("Compression");
 					switch (m_GT1GTextures[i].Format)
 					{
 					case PixelFormat::RGBA8_BGRA_u8:
 					case PixelFormat::RGBA8_RGBA_u8:
 					case PixelFormat::ColorMap_u8:
-						ImGui::Text(std::format("raw (0x{:02X})", (unsigned char)m_GT1GTextures[i].Format).c_str()); break;
+						ImGui::TextUnformatted(std::format("raw (0x{:02X})", (unsigned char)m_GT1GTextures[i].Format).c_str()); break;
 					case PixelFormat::CompressedRgbS3tcDxt1Ext_06:
 					case PixelFormat::CompressedRgbS3tcDxt1Ext_59:
-						ImGui::Text(std::format("S3TC DXT1 (0x{:02X})", (unsigned char)m_GT1GTextures[i].Format).c_str()); break;
+						ImGui::TextUnformatted(std::format("S3TC DXT1 (0x{:02X})", (unsigned char)m_GT1GTextures[i].Format).c_str()); break;
 					case PixelFormat::CompressedRgbaS3tcDxt5Ext_08:
 					case PixelFormat::CompressedRgbaS3tcDxt5Ext_5B:
-						ImGui::Text(std::format("S3TC DXT5 (0x{:02X})", (unsigned char)m_GT1GTextures[i].Format).c_str()); break;
+						ImGui::TextUnformatted(std::format("S3TC DXT5 (0x{:02X})", (unsigned char)m_GT1GTextures[i].Format).c_str()); break;
 					default:
-						ImGui::Text("unknown");
+						ImGui::TextUnformatted("unknown");
 					}
 
-					ImGui::TableNextRow();
-					ImGui::TableSetColumnIndex(0); ImGui::Text("Flags");
-					ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_GT1GTextures[i].Flags).c_str());
+					ROW_FORMAT("Flags", "0x{:08X}", m_GT1GTextures[i].Flags);
 
 					if ((m_GT1GTextures[i].Flags >> 24) == 0x10)
 					{
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("ExtraFlags0");
-						ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_GT1GTextures[i].ExtraFlags0).c_str());
-
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("ExtraFlags1");
-						ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_GT1GTextures[i].ExtraFlags1).c_str());
-
-						ImGui::TableNextRow();
-						ImGui::TableSetColumnIndex(0); ImGui::Text("ExtraFlags2");
-						ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("0x{:08X}", m_GT1GTextures[i].ExtraFlags2).c_str());
+						ROW_FORMAT("ExtraFlags0", "0x{:08X}", m_GT1GTextures[i].ExtraFlags0);
+						ROW_FORMAT("ExtraFlags1", "0x{:08X}", m_GT1GTextures[i].ExtraFlags1);
+						ROW_FORMAT("ExtraFlags2", "0x{:08X}", m_GT1GTextures[i].ExtraFlags2);
 					}
 
 					ImGui::EndTable();
@@ -169,24 +139,24 @@ namespace NGMC
 				if (ImGui::BeginTable(std::format("tablePreviewerGT1GTexture{}MipMaps", i).c_str(), 1 + m_GT1GTextures[i].MipMapCount, Preview::tableFlags))
 				{
 					ImGui::TableNextRow();
-					ImGui::TableSetColumnIndex(0); ImGui::Text("MipMap level");
+					ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("MipMap level");
 					for (unsigned int j = 0; j < m_GT1GTextures[i].MipMapCount; j++)
 					{
-						ImGui::TableSetColumnIndex(1 + j); ImGui::Text(std::format("{}", j).c_str());
+						ImGui::TableSetColumnIndex(1 + j); ImGui::TextUnformatted(std::format("{}", j).c_str());
 					}
 
 					ImGui::TableNextRow();
-					ImGui::TableSetColumnIndex(0); ImGui::Text("Width");
+					ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("Width");
 					for (unsigned int j = 0; j < m_GT1GTextures[i].MipMapCount; j++)
 					{
-						ImGui::TableSetColumnIndex(1 + j); ImGui::Text(std::format("{}", m_GT1GTextures[i].MipMaps[j].Width).c_str());
+						ImGui::TableSetColumnIndex(1 + j); ImGui::TextUnformatted(std::format("{}", m_GT1GTextures[i].MipMaps[j].Width).c_str());
 					}
 
 					ImGui::TableNextRow();
-					ImGui::TableSetColumnIndex(0); ImGui::Text("Height");
+					ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted("Height");
 					for (unsigned int j = 0; j < m_GT1GTextures[i].MipMapCount; j++)
 					{
-						ImGui::TableSetColumnIndex(1 + j); ImGui::Text(std::format("{}", m_GT1GTextures[i].MipMaps[j].Height).c_str());
+						ImGui::TableSetColumnIndex(1 + j); ImGui::TextUnformatted(std::format("{}", m_GT1GTextures[i].MipMaps[j].Height).c_str());
 					}
 
 					ImGui::EndTable();
@@ -195,7 +165,7 @@ namespace NGMC
 		}
 		else
 		{
-			ImGui::Text("No textures were found in this file. This is unexpected.");
+			ImGui::TextUnformatted("No textures were found in this file. This is unexpected.");
 		}
 	}
 

--- a/NGMCToolGUI/previews/PreviewLANG.cpp
+++ b/NGMCToolGUI/previews/PreviewLANG.cpp
@@ -15,7 +15,7 @@ namespace NGMC
 		{
 			ImGui::Dummy({});
 
-			ImGui::Text(std::format("LANG \"{}\"", m_Root.name).c_str());
+			ImGui::TextUnformatted(std::format("LANG \"{}\"", m_Root.name).c_str());
 
 			if (ImGui::BeginTable("tablePreviewerLANG", 1, Preview::tableFlags))
 			{
@@ -70,7 +70,7 @@ namespace NGMC
 										for (unsigned int k = 0; k < m_Content[i].second[j].first.header.childCount; k++)
 										{
 											ImGui::TableNextRow();
-											ImGui::TableSetColumnIndex(0); ImGui::Text(m_Content[i].second[j].second[k].c_str());
+											ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted(m_Content[i].second[j].second[k].c_str());
 										}
 
 										ImGui::EndTable();
@@ -117,49 +117,17 @@ namespace NGMC
 		uintptr_t headerAddr = (uintptr_t)&header;
 		if (ImGui::BeginTable(std::vformat("header##{:08X}", std::make_format_args(headerAddr)).c_str(), 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Signature");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("\"{}\"", header.magic).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Version");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}.{}.{}.{}", header.version.v[0], header.version.v[1], header.version.v[2], header.version.v[3]).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_0C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.dat_0C).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("chunkSize");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(header.chunkSize).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("childCount");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.childCount).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_18");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.dat_18).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_1C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.dat_1C).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("childOffsetsOffset");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.childOffsetsOffset).c_str());
-			
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("extraDataOffset");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.extraDataOffset).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_28");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.dat_28).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_2C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.dat_2C).c_str());
+			ROW_QUOTE("Signature", header.magic);
+			ROW_FORMAT("Version", "{}.{}.{}.{}", header.version.v[0], header.version.v[1], header.version.v[2], header.version.v[3]);
+			ROW_VALUE("dat_0C", header.dat_0C);
+			ROW_VALUE("chunkSize", header.chunkSize);
+			ROW_VALUE("childCount", header.childCount);
+			ROW_VALUE("dat_18", header.dat_18);
+			ROW_VALUE("dat_1C", header.dat_1C);
+			ROW_VALUE("childOffsetsOffset", header.childOffsetsOffset);
+			ROW_VALUE("extraDataOffset", header.extraDataOffset);
+			ROW_VALUE("dat_28", header.dat_28);
+			ROW_VALUE("dat_2C", header.dat_2C);
 
 			ImGui::EndTable();
 		}
@@ -169,29 +137,14 @@ namespace NGMC
 	{
 		if (ImGui::BeginTable("tablePreviewerLANG2", 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Chunk Header");
-			ImGui::TableSetColumnIndex(1); OnRenderChunkHeader(node.header);
+			ROW_BEGIN("Chunk Header");
+			OnRenderChunkHeader(node.header);
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Identifier");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("\"{}\"", node.name).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_40");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_40).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_44");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_44).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_48");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_48).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_4C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_4C).c_str());
+			ROW_QUOTE("Identifier", node.name);
+			ROW_VALUE("dat_40", node.dat_40);
+			ROW_VALUE("dat_44", node.dat_44);
+			ROW_VALUE("dat_48", node.dat_48);
+			ROW_VALUE("dat_4C", node.dat_4C);
 
 			ImGui::EndTable();
 		}
@@ -201,45 +154,18 @@ namespace NGMC
 	{
 		if (ImGui::BeginTable("tablePreviewerLANGCTGPACK2", 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Header");
-			ImGui::TableSetColumnIndex(1); OnRenderChunkHeader(node.header);
+			ROW_BEGIN("Header");
+			OnRenderChunkHeader(node.header);
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Identifier");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("\"{}\"", node.name).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_40");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_40).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_44");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_44).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_48");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_48).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_4C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_4C).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_50");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_50).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_54");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_54).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_58");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_58).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_5C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_5C).c_str());
+			ROW_QUOTE("Identifier", node.name);
+			ROW_VALUE("dat_40", node.dat_40);
+			ROW_VALUE("dat_44", node.dat_44);
+			ROW_VALUE("dat_48", node.dat_48);
+			ROW_VALUE("dat_4C", node.dat_4C);
+			ROW_VALUE("dat_50", node.dat_50);
+			ROW_VALUE("dat_54", node.dat_54);
+			ROW_VALUE("dat_58", node.dat_58);
+			ROW_VALUE("dat_5C", node.dat_5C);
 
 			ImGui::EndTable();
 		}
@@ -249,45 +175,18 @@ namespace NGMC
 	{
 		if (ImGui::BeginTable("tablePreviewerLANGCTGPACKSTRPACK2", 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Header");
-			ImGui::TableSetColumnIndex(1); OnRenderChunkHeader(node.header);
+			ROW_BEGIN("Header");
+			OnRenderChunkHeader(node.header);
 
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Identifier");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("\"{}\"", node.name).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_40");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_40).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_44");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_44).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_48");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_48).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_4C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_4C).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_50");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_50).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_54");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_54).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_58");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_58).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("dat_5C");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", node.dat_5C).c_str());
+			ROW_QUOTE("Identifier", node.name);
+			ROW_VALUE("dat_40", node.dat_40);
+			ROW_VALUE("dat_44", node.dat_44);
+			ROW_VALUE("dat_48", node.dat_48);
+			ROW_VALUE("dat_4C", node.dat_4C);
+			ROW_VALUE("dat_50", node.dat_50);
+			ROW_VALUE("dat_54", node.dat_54);
+			ROW_VALUE("dat_58", node.dat_58);
+			ROW_VALUE("dat_5C", node.dat_5C);
 
 			ImGui::EndTable();
 		}

--- a/NGMCToolGUI/previews/PreviewTMC.cpp
+++ b/NGMCToolGUI/previews/PreviewTMC.cpp
@@ -23,34 +23,25 @@ namespace NGMC
 
 			if (ImGui::BeginTable("tablePreviewerTMC", 2, Preview::tableFlags))
 			{
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Header");
-				ImGui::TableSetColumnIndex(1); OnRenderTMCChunkHeader(m_Header);
+				ROW_BEGIN("Header");
+				OnRenderTMCChunkHeader(m_Header);
 
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Identifier");
-				ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("\"{}\"", m_Header.identifier).c_str());
+				ROW_QUOTE("Identifier", m_Header.identifier);
 
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("U15");
-				ImGui::TableSetColumnIndex(1);
-
+				ROW_BEGIN("U15");
 				if (ImGui::BeginTable("tablePreviewerTMCU15", 1, Preview::tableFlags))
 				{
 					for (unsigned int i = 0; i < m_TMC_U15.size(); i++)
 					{
 						ImGui::TableNextRow();
 						ImGui::TableSetColumnIndex(0);
-						ImGui::Text(std::format("{}", m_TMC_U15[i]).c_str());
+						ImGui::TextUnformatted(std::format("{}", m_TMC_U15[i]).c_str());
 					}
 
 					ImGui::EndTable();
 				}
 				
-				ImGui::TableNextRow();
-				ImGui::TableSetColumnIndex(0); ImGui::Text("Chunks");
-				ImGui::TableSetColumnIndex(1);
-
+				ROW_BEGIN("Chunks");
 				if (ImGui::BeginTable("tablePreviewerTMCChunkIDs", 3, Preview::tableFlags))
 				{
 					ImGui::TableSetupColumn("ID");
@@ -64,18 +55,18 @@ namespace NGMC
 						for (unsigned int i = 0; i < m_TMC_S1_ChunkIDs.size(); i++)
 						{
 							ImGui::TableNextRow();
-							ImGui::TableSetColumnIndex(0); ImGui::Text(std::format("0x{:08X}", (uint32_t)m_TMC_S1_ChunkIDs[i]).c_str());
-							ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", GetChunkTypeName(m_TMC_S1_ChunkIDs[i])).c_str());
-							ImGui::TableSetColumnIndex(2); ImGui::Text(GetPrettySize(m_TMC_ChunkOffsets[i]).c_str());
+							ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted(std::format("0x{:08X}", (uint32_t)m_TMC_S1_ChunkIDs[i]).c_str());
+							ImGui::TableSetColumnIndex(1); ImGui::TextUnformatted(std::format("{}", GetChunkTypeName(m_TMC_S1_ChunkIDs[i])).c_str());
+							ImGui::TableSetColumnIndex(2); ImGui::TextUnformatted(GetPrettySize(m_TMC_ChunkOffsets[i]).c_str());
 						}
 						break;
 					case vSIGMA2:
 						for (unsigned int i = 0; i < m_TMC_S2_ChunkIDs.size(); i++)
 						{
 							ImGui::TableNextRow();
-							ImGui::TableSetColumnIndex(0); ImGui::Text(std::format("0x{:08X}", (uint32_t)m_TMC_S2_ChunkIDs[i]).c_str());
-							ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", GetChunkTypeName(m_TMC_S2_ChunkIDs[i])).c_str());
-							ImGui::TableSetColumnIndex(2); ImGui::Text(GetPrettySize(m_TMC_ChunkOffsets[i]).c_str());
+							ImGui::TableSetColumnIndex(0); ImGui::TextUnformatted(std::format("0x{:08X}", (uint32_t)m_TMC_S2_ChunkIDs[i]).c_str());
+							ImGui::TableSetColumnIndex(1); ImGui::TextUnformatted(std::format("{}", GetChunkTypeName(m_TMC_S2_ChunkIDs[i])).c_str());
+							ImGui::TableSetColumnIndex(2); ImGui::TextUnformatted(GetPrettySize(m_TMC_ChunkOffsets[i]).c_str());
 						}
 						break;
 					}
@@ -124,45 +115,16 @@ namespace NGMC
 		uintptr_t headerAddr = (uintptr_t)&header;
 		if (ImGui::BeginTable(std::vformat("header##{:08X}", std::make_format_args(headerAddr)).c_str(), 2, Preview::tableFlags))
 		{
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Signature");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("\"{}\"", header.magic).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("Version");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}.{}.{}.{}", header.version.v[0], header.version.v[1], header.version.v[2], header.version.v[3]).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("U01");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.U01).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("chunkSize");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(GetPrettySize(header.chunkSize).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("childCount");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.childCount).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("U03");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.U03).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("U04");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.U04).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("U05");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.U05).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("U06");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.U06).c_str());
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0); ImGui::Text("U07");
-			ImGui::TableSetColumnIndex(1); ImGui::Text(std::format("{}", header.U07).c_str());
+			ROW_QUOTE("Signature", header.magic);
+			ROW_FORMAT("Version", "{}.{}.{}.{}", header.version.v[0], header.version.v[1], header.version.v[2], header.version.v[3]);
+			ROW_VALUE("U01", header.U01);
+			ROW_VALUE("chunkSize", header.chunkSize);
+			ROW_VALUE("childCount", header.childCount);
+			ROW_VALUE("U03", header.U03);
+			ROW_VALUE("U04", header.U04);
+			ROW_VALUE("U05", header.U05);
+			ROW_VALUE("U06", header.U06);
+			ROW_VALUE("U07", header.U07);
 
 			ImGui::EndTable();
 		}

--- a/NGMCToolGUI/stdafx.h
+++ b/NGMCToolGUI/stdafx.h
@@ -7,12 +7,11 @@
 
 //#include "targetver.h"
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 // Windows Header Files
 #include <windows.h>
 #include <winternl.h>
 #include <imagehlp.h>
-
 
 #ifdef DLL_EXPORT
 #define DINPUT8_API __declspec(dllexport)
@@ -40,3 +39,36 @@
 #include <GLES2/gl2.h>
 #endif
 #include <GLFW/glfw3.h> // Will drag system OpenGL headers
+
+// basic table macros
+#define ROW_BEGIN(name)            \
+	ImGui::TableNextRow();         \
+	ImGui::TableSetColumnIndex(0); \
+	ImGui::TextUnformatted(name);  \
+	ImGui::TableSetColumnIndex(1)
+
+#define ROW_CSTRING(name, cstring) \
+	ROW_BEGIN(name);               \
+	ImGui::TextUnformatted(cstring)
+
+#define ROW_FORMAT(name, ...) \
+	ROW_BEGIN(name);          \
+	ImGui::TextUnformatted(std::format(__VA_ARGS__).c_str())
+
+#define ROW_STRING(name, string) \
+	ROW_BEGIN(name);             \
+	ImGui::TextUnformatted((string).c_str())
+
+// extended table macros
+#define ROW_PRINTF(name, ...) \
+	ROW_BEGIN(name);          \
+	ImGui::Text(__VA_ARGS__)
+
+#define ROW_QUOTE(name, value) \
+	ROW_FORMAT(name, "\"{}\"", value)
+
+#define ROW_SIZE(name, size) \
+	ROW_STRING(name, GetPrettySize(size))
+
+#define ROW_VALUE(name, value) \
+	ROW_FORMAT(name, "{}", value)


### PR DESCRIPTION
1) Crash fix, reproduce like this:
- open sigma2 databin
- go to 00003.LANG, strpack 2 => crash

Why does it crash? Because ImGui::Text(something) was used and the something contained %s, without argument.
ImGui::Text always formats (like printf) => replaced with ImGui::TextUnformatted

2) Made the code more compact using macros for very repetitive things having lots of copy paste => it's also a lot more readable now, and faster too because it's not using Text when not needed.
- you might want to move the macros somewhere else than stdafx.h
- you might want to replace them with functions (not so important I think)

Basically I was just going to fix the crash then thought I might as well do #2.
Now I see some other things that could be done.